### PR TITLE
Add default fonts and Linux desktop packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,5 +104,14 @@ install(TARGETS GnotePad
     RUNTIME DESTINATION bin
 )
 
+if(UNIX AND NOT APPLE)
+    set(GNOTE_DESKTOP_FILE ${CMAKE_CURRENT_BINARY_DIR}/gnotepad.desktop)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/gnotepad.desktop.in ${GNOTE_DESKTOP_FILE} @ONLY)
+    install(FILES ${GNOTE_DESKTOP_FILE} DESTINATION share/applications)
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/resources/icons/gnotepad-icon.svg
+        DESTINATION share/icons/hicolor/scalable/apps
+        RENAME gnotepad.svg)
+endif()
+
 enable_testing()
 add_subdirectory(tests)

--- a/packaging/linux/gnotepad.desktop.in
+++ b/packaging/linux/gnotepad.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=@PROJECT_VERSION@
+Type=Application
+Name=GnotePad
+Comment=Lightweight Qt-based text editor
+Exec=GnotePad
+Icon=gnotepad
+Terminal=false
+Categories=Utility;TextEditor;
+StartupNotify=true
+StartupWMClass=GnotePad

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -3,6 +3,7 @@
 #include <QCoreApplication>
 #include <QGuiApplication>
 #include <QString>
+#include <QIcon>
 
 #include <spdlog/spdlog.h>
 
@@ -42,11 +43,22 @@ void Application::configureMetadata()
     QCoreApplication::setOrganizationDomain("gnotepad.app");
     QCoreApplication::setApplicationName("GnotePad");
     QCoreApplication::setApplicationVersion(QString::fromLatin1(GNOTE_VERSION));
+#if defined(Q_OS_LINUX)
+    QGuiApplication::setDesktopFileName(QStringLiteral("gnotepad.desktop"));
+#endif
 }
 
 void Application::configureIcon()
 {
+#if defined(Q_OS_LINUX)
+    m_applicationIcon = QIcon::fromTheme(QStringLiteral("gnotepad"));
+    if(m_applicationIcon.isNull())
+    {
+        m_applicationIcon = QIcon(QStringLiteral(":/gnotepad-icon.svg"));
+    }
+#else
     m_applicationIcon = QIcon(QStringLiteral(":/gnotepad-icon.svg"));
+#endif
     if(m_applicationIcon.isNull())
     {
         spdlog::warn("Failed to load embedded application icon; UI will fall back to default icons");

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -56,6 +56,7 @@ private:
     void updateWindowTitle();
     void updateDocumentStats();
     void updateZoomLabel(int percentage);
+    void applyDefaultEditorFont();
 
     bool loadDocumentFromPath(const QString& filePath);
     bool saveDocumentToPath(const QString& filePath);

--- a/src/ui/TextEditor.cpp
+++ b/src/ui/TextEditor.cpp
@@ -110,14 +110,16 @@ void TextEditor::lineNumberAreaPaintEvent(QPaintEvent* event)
     int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
     int bottom = top + static_cast<int>(blockBoundingRect(block).height());
 
-    const QColor textColor = palette().color(QPalette::Disabled, QPalette::Text);
+    const QColor inactiveColor = palette().color(QPalette::Disabled, QPalette::Text);
+    const QColor activeColor = palette().color(QPalette::Text);
+    const int currentBlockNumber = textCursor().blockNumber();
 
     while(block.isValid() && top <= event->rect().bottom())
     {
         if(block.isVisible() && bottom >= event->rect().top())
         {
             const QString number = QString::number(blockNumber + 1);
-            painter.setPen(textColor);
+            painter.setPen(blockNumber == currentBlockNumber ? activeColor : inactiveColor);
             painter.drawText(0, top, m_lineNumberArea->width() - 6, fontMetrics().height(), Qt::AlignRight, number);
         }
 


### PR DESCRIPTION
## Summary
- apply platform-specific monospaced defaults via QFontDatabase and sync tab stops; keep the Line Numbers toggle in sync with the editor
- improve Linux desktop integration by installing a generated .desktop file plus the SVG icon and teaching the application to honor the desktop file name and prefer theme icons
- polish the editor UX by highlighting the active line number, fixing the F5 timestamp formatting, and ensuring replace-all advances correctly

## Testing
- cmake -S . -B build/debug -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 -DCMAKE_BUILD_TYPE=Debug && cmake --build build/debug
- ctest --test-dir build/debug
