### PR TITLE
refactor(ci): use project scripts instead of inline commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,34 +15,29 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Add LLVM apt repo and install clang 21
+    - name: Add LLVM apt repo and install clang-format 21
       run: |
         set -euo pipefail
-        sudo apt-get update
-        # Add the official LLVM apt repository to get clang 21 packages
         wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         CODENAME=$(lsb_release -cs)
         sudo bash -c "echo \"deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-21 main\" > /etc/apt/sources.list.d/llvm-21.list"
         sudo apt-get update
-        sudo apt-get install -y clang-21 clang-format-21 clang-tidy-21
-        echo "clang version: $(clang-21 --version | head -n1)"
+        sudo apt-get install -y clang-format-21
         echo "clang-format version: $(clang-format-21 --version)"
 
     - name: Check code formatting
-      run: |
-        set -euo pipefail
-        # Find tracked C/C++ files under src/ and tests/
-        files=$(git ls-files '*.cpp' '*.h' | grep -E '^(src/|tests/)' || true)
-        if [ -z "$files" ]; then
-          echo "No C/C++ files to check"
-          exit 0
-        fi
+      run: ./tools/check-format.sh
 
-        echo "Files to check:"
-        echo "$files"
+  include-order-check:
+    name: Include Order Check
+    runs-on: ubuntu-24.04
 
-        # Run clang-format in dry-run mode using repository style
-        echo "$files" | xargs -r clang-format-21 --dry-run --Werror --style=file
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Check include order
+      run: ./tools/check-include-order.sh
 
   static-analysis:
     name: Static Analysis (clang-tidy)
@@ -52,31 +47,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Add LLVM apt repo and install tooling (clang 21 + tools)
+    - name: Add LLVM apt repo and install tooling
       run: |
         set -euo pipefail
         wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         CODENAME=$(lsb_release -cs)
         sudo bash -c "echo \"deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-21 main\" > /etc/apt/sources.list.d/llvm-21.list"
         sudo apt-get update
-        sudo apt-get install -y clang-21 clang-tidy-21 ninja-build cmake \
+        sudo apt-get install -y clang-21 clang-tidy-21 lld-21 ninja-build cmake \
           libxkbcommon-dev qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-svg-dev
-        clang-21 --version || true
-        clang-tidy-21 --version || true
+        echo "clang-tidy version: $(clang-tidy-21 --version | head -n1)"
 
-    - name: Configure CMake
+    - name: Configure and run clang-tidy
       run: |
-        cmake -S . -B build -G Ninja \
-          -DCMAKE_CXX_COMPILER=clang++-21 \
-          -DCMAKE_CXX_STANDARD=23 \
-          -DCMAKE_CXX_FLAGS="-std=c++23" \
-          -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
-    - name: Run clang-tidy (via CMake target)
-      run: |
-        cmake --build build --target run-clang-tidy
+        ./tools/configure.sh debug
+        ./tools/clang-tidy.sh
 
   build-and-test:
     name: Build and Test
@@ -84,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        build-type: [Debug, Release]
+        build-type: [debug, release]
 
     runs-on: ${{ matrix.os }}
 
@@ -92,42 +77,28 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Add LLVM apt repo and install dependencies (Linux)
-      if: runner.os == 'Linux'
+    - name: Add LLVM apt repo and install dependencies
       run: |
         set -euo pipefail
         wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         CODENAME=$(lsb_release -cs)
         sudo bash -c "echo \"deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-21 main\" > /etc/apt/sources.list.d/llvm-21.list"
         sudo apt-get update
-        sudo apt-get install -y clang-21 clang-format-21 ninja-build cmake \
+        sudo apt-get install -y clang-21 lld-21 ninja-build cmake \
           libxkbcommon-dev qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-svg-dev
-        clang-21 --version || true
-        clang-format-21 --version || true
+        echo "clang version: $(clang-21 --version | head -n1)"
 
-    - name: Configure CMake
-      run: |
-        cmake -S . -B build -G Ninja \
-          -DCMAKE_CXX_COMPILER=clang++-21 \
-          -DCMAKE_CXX_STANDARD=23 \
-          -DCMAKE_CXX_FLAGS="-std=c++23" \
-          -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/Qt6 \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+    - name: Configure
+      run: ./tools/configure.sh ${{ matrix.build-type }}
 
     - name: Build
-      run: cmake --build build
+      run: ./tools/build.sh ${{ matrix.build-type }}
 
     - name: Install Xvfb and GL libs
-      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install -y xvfb mesa-utils mesa-utils-extra libegl-mesa0 libgl1-mesa-dri libgbm1
 
-    - name: Run tests (Linux with Xvfb)
-      if: runner.os == 'Linux'
+    - name: Run tests
       run: |
-        xvfb-run -a -s "-screen 0 1920x1080x24" ctest --test-dir build --output-on-failure
-
-    - name: Run tests (Non-Linux)
-      if: runner.os != 'Linux'
-      run: ctest --test-dir build --output-on-failure
+        xvfb-run -a -s "-screen 0 1920x1080x24" ctest --test-dir build/${{ matrix.build-type }} --output-on-failure


### PR DESCRIPTION
- format-check: Use ./tools/check-format.sh
- static-analysis: Use ./tools/configure.sh + ./tools/clang-tidy.sh
- build-and-test: Use ./tools/configure.sh + ./tools/build.sh
- Add new include-order-check job using ./tools/check-include-order.sh
- Add lld-21 to dependencies (required by configure.sh)
- Matrix build-type now lowercase to match script arguments
- Simplified: removed redundant runner.os conditionals (only Linux)